### PR TITLE
Update organization references to opencadc-metadata-curation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update --no-install-recommends  && apt-get dist-upgrade -y && \
 WORKDIR /usr/src/app
 
 ARG OPENCADC_BRANCH=main
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 
 RUN git clone https://github.com/${OPENCADC_REPO}/caom2tools.git && \
     cd caom2tools && \

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://github.com/opencadc/collection2caom2/wiki/config.yml.
 1. Copy the file `config.yml` to the working directory. e.g.:
 
    ```
-   wget https://github.com/opencadc/taosii2caom2/blob/5a5e79a33677c15cbcf15975b0ddb85d5c6892f4/config/config.yml
+   wget https://github.com/opencadc-metadata-curation/taosii2caom2/blob/5a5e79a33677c15cbcf15975b0ddb85d5c6892f4/config/config.yml
    ```
 1. In `config.yml`, set the value of `tap_id` to `ivo://cadc.nrc.ca/ams/shared`
 
@@ -72,8 +72,8 @@ https://github.com/opencadc/collection2caom2/wiki/config.yml.
 1. In the main branch of this repository, find the scripts directory, and copy the files `taosii_run.sh`  and `taosii_run_incremental.sh` to the working directory. e.g.:
 
    ```
-   wget https://github.com/opencadc/taosii2caom2/blob/5a5e79a33677c15cbcf15975b0ddb85d5c6892f4/scripts/taosii_run.sh
-   wget https://github.com/opencadc/taosii2caom2/blob/5a5e79a33677c15cbcf15975b0ddb85d5c6892f4/scripts/taosii_run_incremental.sh
+   wget https://github.com/opencadc-metadata-curation/taosii2caom2/blob/5a5e79a33677c15cbcf15975b0ddb85d5c6892f4/scripts/taosii_run.sh
+   wget https://github.com/opencadc-metadata-curation/taosii2caom2/blob/5a5e79a33677c15cbcf15975b0ddb85d5c6892f4/scripts/taosii_run_incremental.sh
    ```
 
 1. Ensure the scripts are executable:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Set up a working directory location, on a machine with Docker installed. The mac
 `taosii2caom2` can store files from local disk to CADC storage. This behaviour is controlled by configuration
 information, located in a file named `config.yml`. Most of the `config.yml` values are already set appropriately, but there are a few values that need to be
 set according to the execution environment. For a complete description of the `config.yml` content, see
-https://github.com/opencadc/collection2caom2/wiki/config.yml.
+https://github.com/opencadc-metadata-curation/collection2caom2/wiki/config.yml.
 
 1. Copy the file `config.yml` to the working directory. e.g.:
 
@@ -120,8 +120,8 @@ https://github.com/opencadc/collection2caom2/wiki/config.yml.
    ```
 
 1. For some instructions that might be helpful on using containers, see:
-   https://github.com/opencadc/collection2caom2/wiki/Docker-and-Collections
+   https://github.com/opencadc-metadata-curation/collection2caom2/wiki/Docker-and-Collections
 
-1. For some insight into what's happening, see: https://github.com/opencadc/collection2caom2
+1. For some insight into what's happening, see: https://github.com/opencadc-metadata-curation/collection2caom2
 
 1. For Docker information, see: https://www.docker.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/taosii2caom2
+github_project = opencadc-metadata-curation/taosii2caom2
 install_requires =
     cadcdata
     cadctap


### PR DESCRIPTION
This PR updates all references from `opencadc` to `opencadc-metadata-curation` following the repository transfer.

## Changes
- Updated Dockerfile dependencies and base images\n- Updated README documentation\n- Updated shell scripts\n
## Files Modified
```
Dockerfile
README.md
scripts/taosii_run.sh
scripts/taosii_run_incremental.sh
```

## Related
- Repository migration to opencadc-metadata-curation organization
- Ensures all references point to the correct organization

## Testing
- Verify builds pass
- Verify all references are updated correctly
